### PR TITLE
Drop Ruby 3.2 from the precompiled list

### DIFF
--- a/lib/what_you_say/version.rb
+++ b/lib/what_you_say/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class WhatYouSay
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end


### PR DESCRIPTION
See https://github.com/gjtorikian/what_you_say/pull/46 for rationale; literally cannot push this gem to RubyGems as-is (eg see 413 errors [here](https://github.com/gjtorikian/what_you_say/actions/runs/24106147524/job/70329782981)). 